### PR TITLE
Update La Banque Postale with non-microG test

### DIFF
--- a/src/data/Plexus.csv
+++ b/src/data/Plexus.csv
@@ -412,7 +412,7 @@ Koofr,May,2021,X,X,4,No reported issues
 Kraken,February,2021,X,X,4,No reported issues
 Kraken Pro,December,2020,4,No reported issues,X,X
 L'appli Societe Generale,May,2021,X,X,4,No reported issues
-La Banque Postale,July,2021,X,X,4,No reported issues
+La Banque Postale,July,2021,3,Notifications won't work,4,No reported issues
 La Redoute,July,2021,X,X,4,No reported issues
 Lastpass,February,2021,3,Premium may not work,4,No reported issues
 Lawnchair 2,December,2020,4,No reported issues,4,No reported issues


### PR DESCRIPTION
The app works fine without MicroG or Google Apps on LineageOS 18.1.

The only issue is that we can't get notifications.