### PR TITLE
Add brazillian services apps

### DIFF
--- a/src/data/Plexus.csv
+++ b/src/data/Plexus.csv
@@ -76,6 +76,8 @@ Azure app,January,2021,1,"Complains about missing Google Play Services on launch
 Ballz,September,2020,3,"Google Play Services Warning, but no effect",4,No reported issues
 Banco do Brasil,March,2021,X,X,4,No reported issues
 Banco Inter,March,2021,X,X,4,App says that won't work with non official Android builds in the future
+Banco Inter Empresas,September,2021,X,X,4,No reported issues
+Banco Itaú,September,2021,X,X,4,No reported issues
 Bandcamp,September,2020,3,No notifications,4,No reported issues
 Bank of America,December,2020,4,No reported issues,4,No reported issues
 Bank of Ireland Mobile Banking,September,2021,1,"Can't register device, rendering application useless. This is likely due to lack of FCM/Google notification support in GrapheneOS where this was tested.",X,X
@@ -371,6 +373,7 @@ hypo@mobile,July,2021,1,No reported issues,X,X
 hypoGO,July,2021,1,No reported issues,X,X
 iClicker Reef,February,2021,X,X,4,No reported issues
 IDS JMK Poseidon,November,2020,4,Getting location slow,X,X
+iFood,September,2021,X,X,3,"Sometimes the delivery tracking map doesn't show"
 iFunny,February,2021,3,"Google Play Services Warning, but no effect",4,No reported issues
 IMDB app,January,2021,4,No reported issues,X,X
 Imgur,July,2021,2,Sign-in not working,4,No reported issues


### PR DESCRIPTION
Add entries for two brazillian banks - Inter Empresas and Itaú - as well as a food ordering brazillian app, iFood.