### PR TITLE
Updated Among Us (redone because mistake from me)

### DIFF
--- a/src/data/Plexus.csv
+++ b/src/data/Plexus.csv
@@ -52,7 +52,7 @@ Amdroid Alarm Clock,July,2021,4,No reported issues,X,X
 Amegy Bank,February,2021,X,X,4,No reported issues
 American Eagle AE + Aerie,July,2021,X,X,4,No reported issues
 Amex Deutschland,December,2020,3,No push notifications & Google Play Services warning,X,X
-Among Us,March,2021,4,No reported issues,4,No reported issues
+Among Us,March,2022,1,Unusable,1,Unusable
 Ampler,September,2020,4,No reported issues,X,X
 Angry Birds 2,November,2020,X,X,4,No reported issues
 Angry Birds AR: Isle of Pigs,November,2020,X,X,4,No reported issues


### PR DESCRIPTION
Among Us now requieres SafetyNet to work, so can't work without anything, and microG can't baypass SafetyNet yet (without Magisk Module)