### PR TITLE
Add Application ratings to API

### DIFF
--- a/lib/plexus.ex
+++ b/lib/plexus.ex
@@ -6,5 +6,7 @@ defmodule Plexus do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
   """
-  use Boundary, exports: [Accounts, Applications, {Schemas, except: []}], deps: []
+  use Boundary,
+    exports: [Accounts, Applications, ApplicationRatings, {Schemas, except: []}],
+    deps: []
 end

--- a/lib/plexus/application_ratings.ex
+++ b/lib/plexus/application_ratings.ex
@@ -15,6 +15,7 @@ defmodule Plexus.ApplicationRatings do
 
     ApplicationRating
     |> where([ar], ar.application_id == ^application_id)
+    |> order_by(desc: :application_build_number)
     |> Repo.paginate(opts)
   end
 

--- a/lib/plexus/application_ratings.ex
+++ b/lib/plexus/application_ratings.ex
@@ -2,6 +2,22 @@ defmodule Plexus.ApplicationRatings do
   alias Plexus.Repo
   alias Plexus.Schemas.ApplicationRating
 
+  import Ecto.Query
+
+  @spec get_application_rating!(Ecto.UUID.t()) :: ApplicationRating.t()
+  def get_application_rating!(id) do
+    Repo.get!(ApplicationRating, id)
+  end
+
+  @spec list_application_ratings(Ecto.UUID.t(), keyword()) :: Repo.page(ApplicationRating.t())
+  def list_application_ratings(application_id, opts \\ []) do
+    opts = Keyword.take(opts, [:page])
+
+    ApplicationRating
+    |> where([ar], ar.application_id == ^application_id)
+    |> Repo.paginate(opts)
+  end
+
   @doc """
   Creates an application_rating.
   """

--- a/lib/plexus/application_ratings.ex
+++ b/lib/plexus/application_ratings.ex
@@ -1,8 +1,8 @@
 defmodule Plexus.ApplicationRatings do
+  import Ecto.Query
+
   alias Plexus.Repo
   alias Plexus.Schemas.ApplicationRating
-
-  import Ecto.Query
 
   @spec get_application_rating!(Ecto.UUID.t()) :: ApplicationRating.t()
   def get_application_rating!(id) do

--- a/lib/plexus/schemas/application.ex
+++ b/lib/plexus/schemas/application.ex
@@ -4,7 +4,7 @@ defmodule Plexus.Schemas.Application do
   schema "applications" do
     field :name, :string
     field :package, :string
-    has_many :ratings, Schemas.ApplicationRating
+    field :rating, :float, virtual: true
 
     timestamps()
   end
@@ -15,6 +15,5 @@ defmodule Plexus.Schemas.Application do
     application
     |> cast(attrs, @required ++ @optional)
     |> validate_required(@required)
-    |> cast_assoc(:ratings)
   end
 end

--- a/lib/plexus_web/controllers/api/v1/application_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/application_controller.ex
@@ -12,9 +12,10 @@ defmodule PlexusWeb.API.V1.ApplicationController do
     render(conn, "index.json", page: page)
   end
 
-  def create(conn, %{"application" => application_params}) do
-    with {:ok, %Application{} = application} <-
-           Applications.create_application(application_params) do
+  def create(conn, %{"application" => params}) do
+    with {:ok, %Application{id: id}} <- Applications.create_application(params) do
+      application = Applications.get_application!(id)
+
       conn
       |> put_status(:created)
       |> put_resp_header("location", show_path(application))

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -10,4 +10,9 @@ defmodule PlexusWeb.API.V1.RatingController do
     page = ApplicationRatings.list_application_ratings(application_id, opts)
     render(conn, "index.json", page: page)
   end
+
+  def show(conn, %{"id" => id}) do
+    rating = ApplicationRatings.get_application_rating!(id)
+    render(conn, "show.json", rating: rating)
+  end
 end

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -2,6 +2,7 @@ defmodule PlexusWeb.API.V1.RatingController do
   use PlexusWeb, :controller
 
   alias Plexus.ApplicationRatings
+  alias Plexus.Schemas.ApplicationRating
 
   action_fallback PlexusWeb.FallbackController
 
@@ -11,8 +12,24 @@ defmodule PlexusWeb.API.V1.RatingController do
     render(conn, "index.json", page: page)
   end
 
+  def create(conn, %{"application_id" => application_id, "rating" => params}) do
+    params = Map.put(params, "application_id", application_id)
+
+    with {:ok, %ApplicationRating{} = rating} <-
+           ApplicationRatings.create_application_rating(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", show_path(rating))
+      |> render("show.json", rating: rating)
+    end
+  end
+
   def show(conn, %{"id" => id}) do
     rating = ApplicationRatings.get_application_rating!(id)
     render(conn, "show.json", rating: rating)
+  end
+
+  defp show_path(rating) do
+    Routes.v1_rating_path(PlexusWeb.Endpoint, :show, rating.application_id, rating)
   end
 end

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -1,0 +1,13 @@
+defmodule PlexusWeb.API.V1.RatingController do
+  use PlexusWeb, :controller
+
+  alias Plexus.ApplicationRatings
+
+  action_fallback PlexusWeb.FallbackController
+
+  def index(conn, %{"application_id" => application_id} = params) do
+    opts = [page: Map.get(params, "page", 1)]
+    page = ApplicationRatings.list_application_ratings(application_id, opts)
+    render(conn, "index.json", page: page)
+  end
+end

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -13,7 +13,10 @@ defmodule PlexusWeb.API.V1.RatingController do
   end
 
   def create(conn, %{"application_id" => application_id, "rating" => params}) do
-    params = Map.put(params, "application_id", application_id)
+    params =
+      params
+      |> Map.put("application_id", application_id)
+      |> Map.put("status", "approved")
 
     with {:ok, %ApplicationRating{} = rating} <-
            ApplicationRatings.create_application_rating(params) do

--- a/lib/plexus_web/router.ex
+++ b/lib/plexus_web/router.ex
@@ -43,7 +43,7 @@ defmodule PlexusWeb.Router do
 
     scope "/v1", V1, as: :v1 do
       resources "/applications", ApplicationController, only: [:index, :create, :show]
-      resources "/applications/:application_id/ratings", RatingController, only: [:index, :show]
+      resources "/applications/:application_id/ratings", RatingController, only: [:index, :create, :show]
     end
   end
 

--- a/lib/plexus_web/router.ex
+++ b/lib/plexus_web/router.ex
@@ -43,7 +43,9 @@ defmodule PlexusWeb.Router do
 
     scope "/v1", V1, as: :v1 do
       resources "/applications", ApplicationController, only: [:index, :create, :show]
-      resources "/applications/:application_id/ratings", RatingController, only: [:index, :create, :show]
+
+      resources "/applications/:application_id/ratings", RatingController,
+        only: [:index, :create, :show]
     end
   end
 

--- a/lib/plexus_web/router.ex
+++ b/lib/plexus_web/router.ex
@@ -43,7 +43,7 @@ defmodule PlexusWeb.Router do
 
     scope "/v1", V1, as: :v1 do
       resources "/applications", ApplicationController, only: [:index, :create, :show]
-      resources "/applications/:application_id/ratings", RatingController, only: [:index]
+      resources "/applications/:application_id/ratings", RatingController, only: [:index, :show]
     end
   end
 

--- a/lib/plexus_web/router.ex
+++ b/lib/plexus_web/router.ex
@@ -43,6 +43,7 @@ defmodule PlexusWeb.Router do
 
     scope "/v1", V1, as: :v1 do
       resources "/applications", ApplicationController, only: [:index, :create, :show]
+      resources "/applications/:application_id/ratings", RatingController, only: [:index]
     end
   end
 

--- a/lib/plexus_web/views/api/v1/application_view.ex
+++ b/lib/plexus_web/views/api/v1/application_view.ex
@@ -24,7 +24,8 @@ defmodule PlexusWeb.API.V1.ApplicationView do
     %{
       id: application.id,
       name: application.name,
-      package: application.package
+      package: application.package,
+      rating: application.rating
     }
   end
 end

--- a/lib/plexus_web/views/api/v1/rating_view.ex
+++ b/lib/plexus_web/views/api/v1/rating_view.ex
@@ -15,11 +15,16 @@ defmodule PlexusWeb.API.V1.RatingView do
     }
   end
 
+  def render("show.json", %{rating: rating}) do
+    data = render_one(rating, RatingView, "rating.json")
+    %{data: data}
+  end
+
   def render("rating.json", %{rating: rating}) do
     %{
       id: rating.id,
-      version: rating.application_version,
-      build_number: rating.application_build_number,
+      application_version: rating.application_version,
+      application_build_number: rating.application_build_number,
       status: rating.status,
       google_lib: rating.google_lib,
       rating: rating.rating,

--- a/lib/plexus_web/views/api/v1/rating_view.ex
+++ b/lib/plexus_web/views/api/v1/rating_view.ex
@@ -1,0 +1,29 @@
+defmodule PlexusWeb.API.V1.RatingView do
+  use PlexusWeb, :view
+
+  alias PlexusWeb.API.V1.RatingView
+
+  def render("index.json", %{page: page}) do
+    data = render_many(page.entries, RatingView, "rating.json")
+
+    %{
+      data: data,
+      page_number: page.page_number,
+      page_size: page.page_size,
+      total_entries: page.total_entries,
+      total_pages: page.total_pages
+    }
+  end
+
+  def render("rating.json", %{rating: rating}) do
+    %{
+      id: rating.id,
+      version: rating.application_version,
+      build_number: rating.application_build_number,
+      status: rating.status,
+      google_lib: rating.google_lib,
+      rating: rating.rating,
+      notes: rating.notes
+    }
+  end
+end

--- a/test/plexus_web/controllers/api/v1/rating_controller_test.exs
+++ b/test/plexus_web/controllers/api/v1/rating_controller_test.exs
@@ -44,4 +44,21 @@ defmodule PlexusWeb.Controllers.Api.V1.RatingControllerTest do
              } = json_response(conn, 200)["data"]
     end
   end
+
+  describe "create ratings" do
+    test "renders rating when data is valid", %{conn: conn} do
+      attrs = valid_application_rating_attributes()
+
+      conn = post(conn, Routes.v1_rating_path(conn, :create, attrs.application_id), rating: attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.v1_rating_path(conn, :show, attrs.application_id, id))
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.v1_rating_path(conn, :create, application_fixture()), rating: %{})
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
 end

--- a/test/plexus_web/controllers/api/v1/rating_controller_test.exs
+++ b/test/plexus_web/controllers/api/v1/rating_controller_test.exs
@@ -1,0 +1,17 @@
+defmodule PlexusWeb.Controllers.Api.V1.RatingControllerTest do
+  use PlexusWeb.ConnCase, async: true
+
+  import Plexus.ApplicationsFixtures
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all ratings for the given application", %{conn: conn} do
+      application = application_fixture()
+      conn = get(conn, Routes.v1_rating_path(conn, :index, application))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+end

--- a/test/plexus_web/controllers/api/v1/rating_controller_test.exs
+++ b/test/plexus_web/controllers/api/v1/rating_controller_test.exs
@@ -2,6 +2,7 @@ defmodule PlexusWeb.Controllers.Api.V1.RatingControllerTest do
   use PlexusWeb.ConnCase, async: true
 
   import Plexus.ApplicationsFixtures
+  import Plexus.ApplicationRatingsFixtures
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
@@ -12,6 +13,35 @@ defmodule PlexusWeb.Controllers.Api.V1.RatingControllerTest do
       application = application_fixture()
       conn = get(conn, Routes.v1_rating_path(conn, :index, application))
       assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "show" do
+    test "fetches the application rating", %{conn: conn} do
+      application_rating =
+        %{
+          id: id,
+          application_id: application_id,
+          application_version: application_version,
+          application_build_number: application_build_number,
+          rating: rating,
+          notes: notes
+        } = application_rating_fixture()
+
+      conn = get(conn, Routes.v1_rating_path(conn, :show, application_id, id))
+
+      status = to_string(application_rating.status)
+      google_lib = to_string(application_rating.google_lib)
+
+      assert %{
+               "id" => ^id,
+               "application_version" => ^application_version,
+               "application_build_number" => ^application_build_number,
+               "status" => ^status,
+               "google_lib" => ^google_lib,
+               "rating" => ^rating,
+               "notes" => ^notes
+             } = json_response(conn, 200)["data"]
     end
   end
 end

--- a/test/support/fixtures/application_ratings_fixtures.ex
+++ b/test/support/fixtures/application_ratings_fixtures.ex
@@ -1,0 +1,28 @@
+defmodule Plexus.ApplicationRatingsFixtures do
+  def unique_application_version do
+    "#{:rand.uniform(69)}-#{:rand.uniform(69)}-#{:rand.uniform(69)}"
+  end
+
+  def unique_application_build_number, do: System.unique_integer([:positive])
+
+  def valid_application_rating_attributes(attrs \\ %{}) do
+    Enum.into(attrs, %{
+      application_id: Plexus.ApplicationsFixtures.application_fixture().id,
+      application_version: unique_application_version(),
+      application_build_number: unique_application_build_number(),
+      status: :approved,
+      google_lib: :micro_g,
+      rating: 4,
+      notes: "vim > emacs"
+    })
+  end
+
+  def application_rating_fixture(attrs \\ %{}) do
+    {:ok, rating} =
+      attrs
+      |> valid_application_rating_attributes()
+      |> Plexus.ApplicationRatings.create_application_rating()
+
+    rating
+  end
+end


### PR DESCRIPTION
We add the following routes:
| METHOD | path |
| --- | --- |
| GET | /api/v1/applications/:application_id/ratings |
| GET  |  /api/v1/applications/:application_id/ratings/:id |
| POST | /api/v1/applications/:application_id/ratings |

For now I have set all reviews to be approved. We can adjust this later on to `needs_review` as a default if we feel we get too much spam going on.

This is what the body of an application looks like:

<img width="1120" alt="Screenshot 2023-02-18 at 1 27 03 PM" src="https://user-images.githubusercontent.com/20251602/219882305-54ff59cf-9e4a-4cdd-8cb0-cb91b5d7c992.png">

#### Create request Types
| Field | Type |
| --- | --- |
|`application_version` | String|
|`application_build_numebr` | Integer |
| `rating` | Integer |
|`notes` | String |
 |`google_lib` | Enum (`none` or  `micro_g`)|


## Updated
All application objects now return an average rating (2 decimal point precision) or `null` if there are none

By default i filter out only `approved` reviews.

<img width="510" alt="Screenshot 2023-02-18 at 1 26 14 PM" src="https://user-images.githubusercontent.com/20251602/219882279-7137184a-601c-4cb2-b6b6-011d9b2fb986.png">

