### PR TITLE
Remove rating status

### DIFF
--- a/lib/plexus/applications.ex
+++ b/lib/plexus/applications.ex
@@ -7,8 +7,8 @@ defmodule Plexus.Applications do
 
   @spec fetch_application!(Ecto.UUID.t()) :: Application.t()
   def fetch_application!(id) do
-    ratings = approved_ratings()
-    micro_g_ratings = approved_micro_g_ratings()
+    ratings = ratings_query()
+    micro_g_ratings = micro_g_ratings_query()
 
     query =
       from a in Application,
@@ -29,8 +29,8 @@ defmodule Plexus.Applications do
   @spec list_applications(keyword()) :: Repo.page(Application.t())
   def list_applications(opts \\ []) do
     opts = Keyword.take(opts, [:page])
-    ratings = approved_ratings()
-    micro_g_ratings = approved_micro_g_ratings()
+    ratings = ratings_query()
+    micro_g_ratings = micro_g_ratings_query()
 
     query =
       from a in Application,
@@ -48,12 +48,12 @@ defmodule Plexus.Applications do
     Repo.paginate(query, opts)
   end
 
-  defp approved_ratings do
-    from ar in Rating, where: [status: :approved, google_lib: :none]
+  defp ratings_query do
+    from ar in Rating, where: [google_lib: :none]
   end
 
-  defp approved_micro_g_ratings do
-    from ar in Rating, where: [status: :approved, google_lib: :micro_g]
+  defp micro_g_ratings_query do
+    from ar in Rating, where: [google_lib: :micro_g]
   end
 
   @spec create_application(map()) :: {:ok, Application.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/plexus/schemas/enums/rating_status.ex
+++ b/lib/plexus/schemas/enums/rating_status.ex
@@ -1,6 +1,0 @@
-defmodule Plexus.Schemas.Enums.RatingStatus do
-  @google_libs [:needs_review, :approved, :rejected]
-
-  @spec values :: [atom()]
-  def values, do: @google_libs
-end

--- a/lib/plexus/schemas/rating.ex
+++ b/lib/plexus/schemas/rating.ex
@@ -4,7 +4,6 @@ defmodule Plexus.Schemas.Rating do
   schema "ratings" do
     field :application_version, :string
     field :application_build_number, :integer
-    field :status, Ecto.Enum, values: Enums.RatingStatus.values()
     field :google_lib, Ecto.Enum, values: Enums.GoogleLib.values()
     field :score, :integer
     field :notes, :string
@@ -18,7 +17,6 @@ defmodule Plexus.Schemas.Rating do
     :application_version,
     :application_build_number,
     :score,
-    :status,
     :google_lib
   ]
   @optional [:notes]

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -13,10 +13,7 @@ defmodule PlexusWeb.API.V1.RatingController do
   end
 
   def create(conn, %{"application_id" => application_id, "rating" => params}) do
-    params =
-      params
-      |> Map.put("application_id", application_id)
-      |> Map.put("status", "approved")
+    params = Map.put(params, "application_id", application_id)
 
     with {:ok, %Rating{} = rating} <- Ratings.create_rating(params) do
       conn

--- a/lib/plexus_web/views/api/v1/rating_view.ex
+++ b/lib/plexus_web/views/api/v1/rating_view.ex
@@ -25,7 +25,6 @@ defmodule PlexusWeb.API.V1.RatingView do
       id: rating.id,
       application_version: rating.application_version,
       application_build_number: rating.application_build_number,
-      status: rating.status,
       google_lib: rating.google_lib,
       score: rating.score,
       notes: rating.notes

--- a/priv/repo/migrations/20220512005759_create_ratings_table.exs
+++ b/priv/repo/migrations/20220512005759_create_ratings_table.exs
@@ -8,7 +8,6 @@ defmodule Plexus.Repo.Migrations.CreateRatingsTable do
 
       add :application_version, :string, null: false
       add :application_build_number, :integer, null: false
-      add :status, :string, null: false
       add :google_lib, :string, null: false
       add :score, :integer, null: false
       add :notes, :text
@@ -17,6 +16,5 @@ defmodule Plexus.Repo.Migrations.CreateRatingsTable do
 
     create index(:ratings, [:application_id])
     create index(:ratings, [:google_lib])
-    create index(:ratings, [:status])
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,7 +12,6 @@ applications = [
         application_id: "5c369728-3ed1-48b5-920e-88bff883caa1",
         application_version: "7.9.2",
         application_build_number: 70_902_003,
-        status: :approved,
         google_lib: :none,
         score: 3,
         notes: "No notifications"
@@ -29,7 +28,6 @@ applications = [
         application_id: "28493c7c-e981-47d1-a3b6-18e28499aa3f",
         application_version: "8.7.36.905",
         application_build_number: 998,
-        status: :approved,
         google_lib: :none,
         score: 2,
         notes: nil
@@ -39,7 +37,6 @@ applications = [
         application_id: "28493c7c-e981-47d1-a3b6-18e28499aa3f",
         application_version: "8.7.36.905",
         application_build_number: 998,
-        status: :approved,
         google_lib: :micro_g,
         score: 4,
         notes: nil
@@ -49,7 +46,6 @@ applications = [
         application_id: "28493c7c-e981-47d1-a3b6-18e28499aa3f",
         application_version: "8.7.2.1205",
         application_build_number: 767,
-        status: :approved,
         google_lib: :none,
         score: 4,
         notes: nil
@@ -66,7 +62,6 @@ applications = [
         application_id: "7d71ed83-5625-4fe6-8934-5c6904ee070c",
         application_version: "17.22.36",
         application_build_number: 88_902_003,
-        status: :approved,
         google_lib: :none,
         score: 1,
         notes: "Unusable"
@@ -76,7 +71,6 @@ applications = [
         application_id: "7d71ed83-5625-4fe6-8934-5c6904ee070c",
         application_version: "17.22.36",
         application_build_number: 88_902_003,
-        status: :approved,
         google_lib: :micro_g,
         score: 4,
         notes: nil
@@ -93,7 +87,6 @@ applications = [
         application_id: "25a2329f-5d7e-4e0d-a3c3-0815ed83e509",
         application_version: "2.2.0",
         application_build_number: 20199,
-        status: :approved,
         google_lib: :none,
         score: 3,
         notes: nil
@@ -103,7 +96,6 @@ applications = [
         application_id: "25a2329f-5d7e-4e0d-a3c3-0815ed83e509",
         application_version: "2.2.0",
         application_build_number: 20199,
-        status: :approved,
         google_lib: :micro_g,
         score: 4,
         notes: nil

--- a/test/plexus/ratings_test.exs
+++ b/test/plexus/ratings_test.exs
@@ -51,7 +51,6 @@ defmodule Plexus.RatingsTest do
         application_id: nil,
         application_version: nil,
         application_build_number: nil,
-        status: nil,
         google_lib: nil,
         score: 69
       }
@@ -67,8 +66,7 @@ defmodule Plexus.RatingsTest do
                application_id: ["can't be blank"],
                application_version: ["can't be blank"],
                google_lib: ["can't be blank"],
-               score: ["can't be blank"],
-               status: ["can't be blank"]
+               score: ["can't be blank"]
              } = errors_on(changeset)
     end
 
@@ -81,7 +79,6 @@ defmodule Plexus.RatingsTest do
       assert rating.application_id == application.id
       assert rating.application_version == attrs.application_version
       assert rating.application_build_number == attrs.application_build_number
-      assert rating.status == attrs.status
       assert rating.google_lib == attrs.google_lib
       assert rating.score == attrs.score
       assert rating.notes == attrs.notes

--- a/test/plexus_web/controllers/api/v1/rating_controller_test.exs
+++ b/test/plexus_web/controllers/api/v1/rating_controller_test.exs
@@ -29,14 +29,12 @@ defmodule PlexusWeb.Controllers.Api.V1.RatingControllerTest do
 
       conn = get(conn, Routes.v1_rating_path(conn, :show, application_id, id))
 
-      status = to_string(application_rating.status)
       google_lib = to_string(application_rating.google_lib)
 
       assert %{
                "id" => ^id,
                "application_version" => ^application_version,
                "application_build_number" => ^application_build_number,
-               "status" => ^status,
                "google_lib" => ^google_lib,
                "score" => ^score,
                "notes" => ^notes

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -32,7 +32,6 @@ defmodule Plexus.Fixtures do
       application_id: application_fixture().id,
       application_version: unique_application_version(),
       application_build_number: unique_application_build_number(),
-      status: :approved,
       google_lib: google_lib(),
       score: Enum.random(1..4),
       notes: gnu_linux()


### PR DESCRIPTION
For the foreseeable future, all ratings will always be approved. We then have no real use for storing this right at the moment. We could always add it to the database later on if we ever need it.