### PR TITLE
Add ROM data

### DIFF
--- a/lib/plexus/ratings.ex
+++ b/lib/plexus/ratings.ex
@@ -2,7 +2,6 @@ defmodule Plexus.Ratings do
   @moduledoc """
   The Ratings context.
   """
-  import Ecto.Changeset
   import Ecto.Query
 
   alias Plexus.PaginationHelpers
@@ -46,19 +45,19 @@ defmodule Plexus.Ratings do
   end
 
   @spec create_rating(%{
+          optional(:notes) => String.t(),
+          optional(:rom_name) => String.t(),
+          optional(:rom_version) => String.t(),
+          optional(:rom_build) => String.t(),
           app_package: String.t(),
           app_version: String.t(),
           app_build_number: non_neg_integer(),
           google_lib: atom(),
-          score: pos_integer(),
-          notes: String.t()
+          score: pos_integer()
         }) :: {:ok, Rating.t()} | {:error, Ecto.Changeset.t()}
   def create_rating(params) do
     %Rating{}
-    |> cast(params, [:app_package, :app_version, :app_build_number, :google_lib, :score, :notes])
-    |> validate_required([:app_package, :app_version, :app_build_number, :google_lib, :score])
-    |> assoc_constraint(:app)
-    |> validate_number(:score, greater_than_or_equal_to: 1, less_than_or_equal_to: 4)
+    |> Rating.changeset(params)
     |> Repo.insert()
   end
 end

--- a/lib/plexus/schemas/rating.ex
+++ b/lib/plexus/schemas/rating.ex
@@ -8,6 +8,9 @@ defmodule Plexus.Schemas.Rating do
   schema "ratings" do
     field :app_build_number, :integer
     field :app_version, :string
+    field :rom_name, :string
+    field :rom_version, :string
+    field :rom_build, :string
     field :google_lib, Ecto.Enum, values: [:none, :micro_g]
     field :notes, :string
     field :score, :integer
@@ -21,7 +24,7 @@ defmodule Plexus.Schemas.Rating do
   end
 
   @required [:app_package, :app_version, :app_build_number, :google_lib, :score]
-  @optional [:notes]
+  @optional [:notes, :rom_name, :rom_version, :rom_build]
   @doc false
   def changeset(%Rating{} = rating, attrs) do
     rating

--- a/lib/plexus_web/controllers/api/v1/rating_controller.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_controller.ex
@@ -20,6 +20,9 @@ defmodule PlexusWeb.API.V1.RatingController do
       app_package: {:string, [required: true]},
       app_version: {:string, [required: true]},
       app_build_number: {:integer, [required: true]},
+      rom_name: {:string, []},
+      rom_version: {:string, []},
+      rom_build: {:string, []},
       google_lib: {google_lib_enum(), [required: true]},
       notes: {:string, []},
       score: {:integer, [required: true]}

--- a/lib/plexus_web/controllers/api/v1/rating_json.ex
+++ b/lib/plexus_web/controllers/api/v1/rating_json.ex
@@ -20,6 +20,9 @@ defmodule PlexusWeb.API.V1.RatingJSON do
       app_package: rating.app_package,
       app_version: rating.app_version,
       app_build_number: rating.app_build_number,
+      rom_name: rating.rom_name,
+      rom_version: rating.rom_version,
+      rom_build: rating.rom_build,
       score: %{numerator: rating.score, denominator: 4},
       notes: rating.notes,
       google_lib: rating.google_lib

--- a/priv/repo/migrations/20230301014024_create_ratings.exs
+++ b/priv/repo/migrations/20230301014024_create_ratings.exs
@@ -6,6 +6,9 @@ defmodule Plexus.Repo.Migrations.CreateRatings do
       add :id, :binary_id, primary_key: true
       add :app_version, :string, null: false
       add :app_build_number, :integer, null: false
+      add :rom_name, :string
+      add :rom_version, :string
+      add :rom_build, :string
       add :google_lib, :string, null: false
       add :score, :integer, null: false
       add :notes, :text

--- a/test/plexus/ratings_test.exs
+++ b/test/plexus/ratings_test.exs
@@ -41,7 +41,10 @@ defmodule Plexus.RatingsTest do
         app_version: "some app_version",
         google_lib: :none,
         notes: "some notes",
-        score: 3
+        score: 3,
+        rom_name: "some ROM name",
+        rom_version: "some ROM version",
+        rom_build: "some ROM build"
       }
 
       assert {:ok, %Rating{} = rating} = Ratings.create_rating(valid_attrs)
@@ -51,6 +54,9 @@ defmodule Plexus.RatingsTest do
       assert rating.google_lib == :none
       assert rating.notes == "some notes"
       assert rating.score == 3
+      assert rating.rom_name == "some ROM name"
+      assert rating.rom_version == "some ROM version"
+      assert rating.rom_build == "some ROM build"
     end
 
     test "invalid data returns error changeset" do

--- a/test/plexus_web/controllers/api/v1/rating_controller_test.exs
+++ b/test/plexus_web/controllers/api/v1/rating_controller_test.exs
@@ -8,8 +8,12 @@ defmodule PlexusWeb.API.V1.RatingControllerTest do
     app_version: "some app_version",
     google_lib: :none,
     notes: "some notes",
-    score: 2
+    score: 2,
+    rom_name: "some ROM name",
+    rom_version: "some ROM version",
+    rom_build: "some ROM build"
   }
+
   @invalid_attrs %{
     app_build_number: nil,
     app_version: nil,
@@ -59,6 +63,9 @@ defmodule PlexusWeb.API.V1.RatingControllerTest do
                "app_package" => ^app_package,
                "app_build_number" => 42,
                "app_version" => "some app_version",
+               "rom_name" => "some ROM name",
+               "rom_version" => "some ROM version",
+               "rom_build" => "some ROM build",
                "google_lib" => "none",
                "notes" => "some notes",
                "score" => %{"numerator" => 2, "denominator" => 4}


### PR DESCRIPTION
We add the ability to store ROM data for each rating.

We include the optional:
- `rom_name`
- `rom_version`
- `rom_build`

Although we do not use these for anything at the moment, they can be important later on.