### PR TITLE
Add `last_updated` filter to GET /v1/apps 

### DIFF
--- a/lib/plexus/apps.ex
+++ b/lib/plexus/apps.ex
@@ -50,6 +50,14 @@ defmodule Plexus.Apps do
     |> Repo.one!()
   end
 
+  @spec fetch_app(String.t()) :: {:ok, App.t()} | {:error, :not_found}
+  def fetch_app(package) do
+    case Repo.get(App, package) do
+      %App{} = app -> {:ok, app}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec create_app(%{
           optional(:icon_url) => String.t(),
           package: String.t(),
@@ -63,8 +71,9 @@ defmodule Plexus.Apps do
   end
 
   @spec update_app(App.t(), %{
+          optional(:updated_at) => DateTime.t(),
           optional(:icon_url) => String.t(),
-          name: String.t()
+          optional(:name) => String.t()
         }) :: {:ok, App.t()} | {:error, Ecto.Changeset.t()}
   def update_app(%App{} = app, params) do
     app

--- a/lib/plexus/apps.ex
+++ b/lib/plexus/apps.ex
@@ -126,6 +126,9 @@ defmodule Plexus.Apps do
       {_, ""}, query ->
         query
 
+      {:updated_at_greater_than_or_equal_to, dt}, query ->
+        from q in query, where: q.updated_at >= ^dt
+
       {:search_term, search_term}, query ->
         pattern = "%#{search_term}%"
 

--- a/lib/plexus/schemas/app.ex
+++ b/lib/plexus/schemas/app.ex
@@ -20,7 +20,7 @@ defmodule Plexus.Schemas.App do
   @spec changeset(App.t(), map()) :: Ecto.Changeset.t()
   def changeset(%App{} = app, params) do
     app
-    |> cast(params, [:package, :name, :icon_url])
+    |> cast(params, [:package, :name, :icon_url, :updated_at])
     |> validate_required([:package, :name])
     |> unique_constraint(:package, name: :apps_pkey)
   end

--- a/lib/plexus_web/controllers/api/v1/app_json.ex
+++ b/lib/plexus_web/controllers/api/v1/app_json.ex
@@ -19,7 +19,8 @@ defmodule PlexusWeb.API.V1.AppJSON do
     %{
       package: app.package,
       name: app.name,
-      icon_url: app.icon_url
+      icon_url: app.icon_url,
+      updated_at: DateTime.truncate(app.updated_at, :second)
     }
     |> merge_scores(app.scores)
   end

--- a/lib/plexus_web/controllers/api/v1/schemas/app.ex
+++ b/lib/plexus_web/controllers/api/v1/schemas/app.ex
@@ -16,6 +16,7 @@ defmodule PlexusWeb.API.V1.Schemas.App do
     example: %{
       "name" => "Signal",
       "package" => "org.thoughtcrime.securesms",
+      "updated_at" => "2024-04-30T22:41:19Z",
       "scores" => %{
         "native" => %{
           "rating_type" => "native",

--- a/lib/plexus_web/controllers/api/v1/schemas/app_response.ex
+++ b/lib/plexus_web/controllers/api/v1/schemas/app_response.ex
@@ -14,6 +14,7 @@ defmodule PlexusWeb.API.V1.Schemas.AppResponse do
         %{
           "name" => "Signal",
           "package" => "org.thoughtcrime.securesms",
+          "updated_at" => "2024-04-30T22:41:19Z",
           "scores" => %{
             "native" => %{
               "rating_type" => "native",

--- a/lib/plexus_web/controllers/api/v1/schemas/apps_response.ex
+++ b/lib/plexus_web/controllers/api/v1/schemas/apps_response.ex
@@ -17,6 +17,7 @@ defmodule PlexusWeb.API.V1.Schemas.AppsResponse do
         %{
           "name" => "Signal",
           "package" => "org.thoughtcrime.securesms",
+          "updated_at" => "2024-04-30T22:41:19Z",
           "scores" => %{
             "native" => %{
               "rating_type" => "native",

--- a/test/plexus/ratings_test.exs
+++ b/test/plexus/ratings_test.exs
@@ -8,7 +8,7 @@ defmodule Plexus.RatingsTest do
   alias Plexus.Schemas.Rating
 
   @invalid_attrs %{
-    app_package: nil,
+    app_package: "",
     app_build_number: nil,
     app_version: nil,
     rating_type: nil,
@@ -65,7 +65,7 @@ defmodule Plexus.RatingsTest do
     end
 
     test "invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Ratings.create_rating(@invalid_attrs)
+      assert {:error, _reason} = Ratings.create_rating(@invalid_attrs)
     end
   end
 end


### PR DESCRIPTION
We add support to only fetch apps that have been updated since the given date time. 

cc: @StellarSand 

![image](https://github.com/user-attachments/assets/26c72e4c-5e02-49b5-b731-10da3b7dbcce)
