### PR TITLE
Add support for int64 app_build_number

### DIFF
--- a/lib/plexus_web/controllers/api/v1/schemas/rating.ex
+++ b/lib/plexus_web/controllers/api/v1/schemas/rating.ex
@@ -12,7 +12,7 @@ defmodule PlexusWeb.API.V1.Schemas.Rating do
       android_version: %Schema{type: :string, description: "Android Version"},
       app_package: %Schema{type: :string, description: "App Package"},
       app_version: %Schema{type: :string, description: "App Version"},
-      app_build_number: %Schema{type: :integer, description: "App Build Number"},
+      app_build_number: %Schema{type: :integer, format: :int64, description: "App Build Number"},
       rom_name: %Schema{type: :string, description: "ROM Name"},
       rom_build: %Schema{type: :string, description: "ROM Build"},
       installation_source: %Schema{type: :string, description: "Installation Source"},

--- a/priv/repo/migrations/20241106205931_change_app_build_number_to_bigint.exs
+++ b/priv/repo/migrations/20241106205931_change_app_build_number_to_bigint.exs
@@ -1,0 +1,9 @@
+defmodule Plexus.Repo.Migrations.ChangeAppBuildNumberToBigint do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ratings) do
+      modify :app_build_number, :bigint, from: :integer
+    end
+  end
+end


### PR DESCRIPTION
We need to add support for `long` app build versions for the newer android version