### PR TITLE
Clarify that this repoitory is for API/website only

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,3 +39,5 @@ body:
       options:
         - label: This is not a duplicate of another issue.
           required: true
+        - label: This is related only to the API/website & not the [app](https://github.com/techlore/Plexus-app).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,3 +26,5 @@ body:
       options:
         - label: This is not a duplicate of another feature request.
           required: true
+        - label: This is related only to the API/website & not the [app](https://github.com/techlore/Plexus-app).
+          required: true

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ Privacy policy is located [here](https://github.com/techlore/Plexus/blob/main/PR
 ## Issues
 If you find bugs or have suggestions, please report it to the [issue tracker](https://github.com/techlore/Plexus/issues).
 <br>We encourage you to search for existing issues before opening a new one. Any duplicates will be closed.
+> [!NOTE]
+> This issue tracker is for the API/website only.
+<br>For any issues related to the app, please report them [here](https://github.com/techlore/Plexus-app/issues).
 
 
 ## Contributing
-- New pull requests can be submitted [here](https://github.com/techlore/Plexus/pulls).
+- New pull requests related to the API/Website can be submitted [here](https://github.com/techlore/Plexus/pulls).
 - To submit data please use the [Plexus app](https://github.com/techlore/Plexus-app).
 
 


### PR DESCRIPTION
I keep seeing people opening issues here that are related to the app. This PR does the following:
- Clearly states in the README to open issues related to API/website only.
- Include a mandatory checkbox in issues & feature request template for the same.